### PR TITLE
feat: pass content library to router from app entry

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,13 +2,24 @@
   <div id="app">
     <div id="nav">
       <router-link to="/">Home</router-link> |
-      <router-link to="/about">About</router-link>
+      <router-link to="/about">About</router-link> |
+      <router-link to="/blog">Blog</router-link>
     </div>
     <router-view />
   </div>
 </template>
 <script lang="ts">
-export default {};
+import Vue from 'vue';
+import { PropValidator } from 'vue/types/options';
+import { ContentLibraryDataObject } from 'vue.config';
+
+export default Vue.extend({
+  props: {
+    contentLibrary: {
+      type: Object,
+    } as PropValidator<ContentLibraryDataObject>,
+  },
+});
 </script>
 <style lang="scss">
 #app {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,28 @@
 import Vue from 'vue';
+import { ContentLibraryDataObject } from 'vue.config';
 import App from './App.vue';
 import createRouter from './router';
 
 Vue.config.productionTip = false;
 
 export default () => {
-  const router = createRouter();
+  // Webpack converts this variable to a JS object for us,
+  // but TypeScript still thinks it's a string | undefined.
+  // So in order to use the library object, we cast to unknown,
+  // then cast to the correct type.
+  const contentLibrary = process.env.CONTENT_LIBRARY as
+    | ContentLibraryDataObject
+    | undefined;
+
+  const router = createRouter(contentLibrary);
+
   return new Vue({
     router,
-    render: h => h(App),
+    render: h =>
+      h(App, {
+        props: {
+          contentLibrary: contentLibrary,
+        },
+      }),
   });
 };

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -24,12 +24,8 @@ let routes: Array<RouteConfig> = [
   },
 ];
 
-export default () => {
-  // Webpack converts this variable to a JS object for us,
-  // but TypeScript still thinks it's a string | undefined.
-  // So in order to use the library object, we cast to unknown,
-  // then cast to the correct type.
-  const contentLibrary: unknown | undefined = process.env.CONTENT_LIBRARY;
+export default (contentLibrary?: ContentLibraryDataObject) => {
+  let contentRoutes: RouteConfig[] | undefined;
 
   /**
    * Recursively constructs a vue-router configuration from the DirectoryTree
@@ -62,11 +58,13 @@ export default () => {
     };
   };
 
-  const contentRoutes = (contentLibrary as ContentLibraryDataObject)?.contentLibraryChildren?.map(
-    file => buildLibraryRoutes(file),
-  );
+  if (contentLibrary) {
+    contentRoutes = contentLibrary?.contentLibraryChildren?.map(file =>
+      buildLibraryRoutes(file),
+    );
 
-  routes = routes.concat(contentRoutes || []);
+    routes = routes.concat(contentRoutes || []);
+  }
 
   const router = new VueRouter({
     mode: 'history',

--- a/vue.config.ts
+++ b/vue.config.ts
@@ -10,7 +10,14 @@ export interface ArticleMarkdownFile {
 }
 
 export interface ContentLibraryDataObject extends dirTree.DirectoryTree {
+  /**
+   * The raw result from the front-matter library so the app can access
+   * markdown file frontmatter.
+   */
   fileContent?: FrontMatterResult<ArticleMarkdownFile>;
+  /**
+   * The parsed HTML from markdown-it which can be used to render page content.
+   */
   htmlContent?: string;
   contentLibraryChildren?: ContentLibraryDataObject[];
 }


### PR DESCRIPTION
Previously the env variable created by webpack that contains the file tree + parsed markdown was pulled into the app in the router setup file. However, this limited the ability to make the content library available to other parts of the app (for instance, there would be no way to list blog articles in other parts of the app unless we wanted to vue-router for this... which would be weird).

With this change now the original content library can be passed down to the rest of the app through props, to make it available for displaying contextual data, etc.

Closes #2 